### PR TITLE
Implement course use case operations

### DIFF
--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/AssignInstructorUseCaseImpl.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/AssignInstructorUseCaseImpl.java
@@ -3,10 +3,31 @@ package com.borcla.springcloud.msvc.application.usecase;
 import com.borcla.springcloud.msvc.application.exception.CourseNotFoundException;
 import com.borcla.springcloud.msvc.application.ports.in.IAssignInstructorUseCase;
 import com.borcla.springcloud.msvc.application.ports.out.persistence.ICourseRepositoryPort;
+import com.borcla.springcloud.msvc.domain.model.Course;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class AssignInstructorUseCaseImpl implements IAssignInstructorUseCase {
+
+    private final ICourseRepositoryPort courseRepositoryPort;
+
+    public AssignInstructorUseCaseImpl(ICourseRepositoryPort courseRepositoryPort) {
+        this.courseRepositoryPort = courseRepositoryPort;
+    }
+
     @Override
     public void assignInstructor(Long instructorId, Long idCourse) throws CourseNotFoundException {
+        Course course = courseRepositoryPort.findById(idCourse)
+                .orElseThrow(CourseNotFoundException::new);
 
+        Set<Long> instructors = course.getInstructorIds();
+        if (instructors == null) {
+            instructors = new HashSet<>();
+            course.setInstructorIds(instructors);
+        }
+        instructors.add(instructorId);
+
+        courseRepositoryPort.update(course, course.getId());
     }
 }

--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/PublishCourseUseCaseImpl.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/PublishCourseUseCaseImpl.java
@@ -1,15 +1,31 @@
 package com.borcla.springcloud.msvc.application.usecase;
 
+import com.borcla.springcloud.msvc.application.exception.CourseNotFoundException;
 import com.borcla.springcloud.msvc.application.ports.in.IPublishCourseUseCase;
+import com.borcla.springcloud.msvc.application.ports.out.persistence.ICourseRepositoryPort;
+import com.borcla.springcloud.msvc.domain.model.Course;
 
 public class PublishCourseUseCaseImpl implements IPublishCourseUseCase {
+
+    private final ICourseRepositoryPort courseRepositoryPort;
+
+    public PublishCourseUseCaseImpl(ICourseRepositoryPort courseRepositoryPort) {
+        this.courseRepositoryPort = courseRepositoryPort;
+    }
+
     @Override
     public void publishCourse(Long idCourse) {
-
+        Course course = courseRepositoryPort.findById(idCourse)
+                .orElseThrow(CourseNotFoundException::new);
+        course.publish();
+        courseRepositoryPort.update(course, course.getId());
     }
 
     @Override
     public void publishCourseByName(String nameCourse) {
-
+        Course course = courseRepositoryPort.findByName(nameCourse)
+                .orElseThrow(CourseNotFoundException::new);
+        course.publish();
+        courseRepositoryPort.update(course, course.getId());
     }
 }

--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/ReleaseSeatUseCaseImpl.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/ReleaseSeatUseCaseImpl.java
@@ -2,16 +2,31 @@ package com.borcla.springcloud.msvc.application.usecase;
 
 import com.borcla.springcloud.msvc.application.exception.CourseNotFoundException;
 import com.borcla.springcloud.msvc.application.ports.in.IReleaseSeatUseCase;
+import com.borcla.springcloud.msvc.application.ports.out.persistence.ICourseRepositoryPort;
 import com.borcla.springcloud.msvc.domain.exception.CourseFullException;
+import com.borcla.springcloud.msvc.domain.model.Course;
 
 public class ReleaseSeatUseCaseImpl implements IReleaseSeatUseCase {
+
+    private final ICourseRepositoryPort courseRepositoryPort;
+
+    public ReleaseSeatUseCaseImpl(ICourseRepositoryPort courseRepositoryPort) {
+        this.courseRepositoryPort = courseRepositoryPort;
+    }
+
     @Override
     public void releaseSeat(Long idCourse) throws CourseNotFoundException, CourseFullException {
-
+        Course course = courseRepositoryPort.findById(idCourse)
+                .orElseThrow(CourseNotFoundException::new);
+        course.releaseSeat();
+        courseRepositoryPort.update(course, course.getId());
     }
 
     @Override
     public void releaseSeatByName(String name) throws CourseNotFoundException, CourseFullException {
-
+        Course course = courseRepositoryPort.findByName(name)
+                .orElseThrow(CourseNotFoundException::new);
+        course.releaseSeat();
+        courseRepositoryPort.update(course, course.getId());
     }
 }

--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/RemoveInstructorUseCaseImpl.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/RemoveInstructorUseCaseImpl.java
@@ -2,10 +2,26 @@ package com.borcla.springcloud.msvc.application.usecase;
 
 import com.borcla.springcloud.msvc.application.exception.CourseNotFoundException;
 import com.borcla.springcloud.msvc.application.ports.in.IRemoveInstructorUseCase;
+import com.borcla.springcloud.msvc.application.ports.out.persistence.ICourseRepositoryPort;
+import com.borcla.springcloud.msvc.domain.model.Course;
 
 public class RemoveInstructorUseCaseImpl implements IRemoveInstructorUseCase {
+
+    private final ICourseRepositoryPort courseRepositoryPort;
+
+    public RemoveInstructorUseCaseImpl(ICourseRepositoryPort courseRepositoryPort) {
+        this.courseRepositoryPort = courseRepositoryPort;
+    }
+
     @Override
     public void removeInstructor(Long instructorId, Long idCourse) throws CourseNotFoundException {
+        Course course = courseRepositoryPort.findById(idCourse)
+                .orElseThrow(CourseNotFoundException::new);
 
+        if (course.getInstructorIds() != null) {
+            course.getInstructorIds().remove(instructorId);
+        }
+
+        courseRepositoryPort.update(course, course.getId());
     }
 }

--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/ReserveSeatUseCaseImpl.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/ReserveSeatUseCaseImpl.java
@@ -2,11 +2,27 @@ package com.borcla.springcloud.msvc.application.usecase;
 
 import com.borcla.springcloud.msvc.application.exception.CourseNotFoundException;
 import com.borcla.springcloud.msvc.application.ports.in.IReserveSeatUseCase;
+import com.borcla.springcloud.msvc.application.ports.out.persistence.ICourseRepositoryPort;
 import com.borcla.springcloud.msvc.domain.exception.CourseFullException;
+import com.borcla.springcloud.msvc.domain.model.Course;
 
 public class ReserveSeatUseCaseImpl implements IReserveSeatUseCase {
+
+    private final ICourseRepositoryPort courseRepositoryPort;
+
+    public ReserveSeatUseCaseImpl(ICourseRepositoryPort courseRepositoryPort) {
+        this.courseRepositoryPort = courseRepositoryPort;
+    }
+
     @Override
     public void reserve(Long idCourse) throws CourseNotFoundException, CourseFullException {
-
+        Course course = courseRepositoryPort.findById(idCourse)
+                .orElseThrow(CourseNotFoundException::new);
+        try {
+            course.reserveSeat();
+        } catch (IllegalStateException e) {
+            throw new CourseFullException(course.getId(), course.getCapacity(), course.getEnrolledCount());
+        }
+        courseRepositoryPort.update(course, course.getId());
     }
 }

--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/RetrieveCourseUseCaseImpl.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/RetrieveCourseUseCaseImpl.java
@@ -16,16 +16,22 @@ public class RetrieveCourseUseCaseImpl implements IRetrieveCourseUseCase {
 
     @Override
     public Optional<Course> getCourseById(Long idCourse) throws CourseNotFoundException {
-        return courseRepositoryPort.findById(idCourse);
+        Course course = courseRepositoryPort.findById(idCourse)
+                .orElseThrow(CourseNotFoundException::new);
+        return Optional.of(course);
     }
 
     @Override
     public Optional<Course> getCourseByCode(String codeCourse) throws CourseNotFoundException {
-        return courseRepositoryPort.findByCode(codeCourse);
+        Course course = courseRepositoryPort.findByCode(codeCourse)
+                .orElseThrow(CourseNotFoundException::new);
+        return Optional.of(course);
     }
 
     @Override
     public Optional<Course> getCourseByName(String nameCourse) throws CourseNotFoundException {
-        return courseRepositoryPort.findByName(nameCourse);
+        Course course = courseRepositoryPort.findByName(nameCourse)
+                .orElseThrow(CourseNotFoundException::new);
+        return Optional.of(course);
     }
 }


### PR DESCRIPTION
## Summary
- inject course repository into instructor, publish, seat and retrieve use cases
- use domain methods to assign/remove instructors, publish courses and manage seats
- persist updated courses and handle not found/full exceptions

## Testing
- `mvn -q -pl msvc-courses test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b246607e348329b7877ae717320edc