### PR TITLE
Implement course persistence queries for JPA and Mongo

### DIFF
--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/out/persistence/jpa/CourseJpaPersistenceAdapter.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/out/persistence/jpa/CourseJpaPersistenceAdapter.java
@@ -37,27 +37,37 @@ public class CourseJpaPersistenceAdapter implements ICourseRepositoryPort {
 
     @Override
     public Course update(Course course, Long idCourse) {
-        return null;
+        CourseEntity entity = courseJpaMapper.toEntity(course);
+        entity.setId(idCourse);
+        CourseEntity saved = jpaCourseRepository.save(entity);
+        return courseJpaMapper.toDomain(saved);
     }
 
     @Override
     public boolean deleteById(Long id) {
-        return false;
+        if (!jpaCourseRepository.existsById(id)) {
+            return false;
+        }
+        jpaCourseRepository.deleteById(id);
+        return true;
     }
 
     @Override
     public Optional<Course> findById(Long id) {
-        return Optional.empty();
+        return jpaCourseRepository.findById(id)
+                .map(courseJpaMapper::toDomain);
     }
 
     @Override
     public Optional<Course> findByCode(String code) {
-        return Optional.empty();
+        return jpaCourseRepository.findByCode(code)
+                .map(courseJpaMapper::toDomain);
     }
 
     @Override
     public Optional<Course> findByName(String name) {
-        return Optional.empty();
+        return jpaCourseRepository.findByName(name)
+                .map(courseJpaMapper::toDomain);
     }
 
     @Override

--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/out/persistence/jpa/repository/JpaCourseRepository.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/out/persistence/jpa/repository/JpaCourseRepository.java
@@ -7,9 +7,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface JpaCourseRepository extends JpaRepository<CourseEntity, Long> {
     Page<CourseEntity> findByInstructorIdsContains(Long instructorId, Pageable pageable);
     Page<CourseEntity> findByStatus(CourseStatus status, Pageable pageable);
     Page<CourseEntity> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    Optional<CourseEntity> findByCode(String code);
+    Optional<CourseEntity> findByName(String name);
 }

--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/out/persistence/mongo/CourseMongoPersistenceAdapter.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/out/persistence/mongo/CourseMongoPersistenceAdapter.java
@@ -36,27 +36,37 @@ public class CourseMongoPersistenceAdapter implements ICourseRepositoryPort {
 
     @Override
     public Course update(Course course, Long idCourse) {
-        return null;
+        CourseDocument document = courseMongoMapper.toDocument(course);
+        document.setId(idCourse);
+        CourseDocument saved = courseMongoRepository.save(document);
+        return courseMongoMapper.toDomain(saved);
     }
 
     @Override
     public boolean deleteById(Long id) {
-        return false;
+        if (!courseMongoRepository.existsById(id)) {
+            return false;
+        }
+        courseMongoRepository.deleteById(id);
+        return true;
     }
 
     @Override
     public Optional<Course> findById(Long id) {
-        return Optional.empty();
+        return courseMongoRepository.findById(id)
+                .map(courseMongoMapper::toDomain);
     }
 
     @Override
     public Optional<Course> findByCode(String code) {
-        return Optional.empty();
+        return courseMongoRepository.findByCode(code)
+                .map(courseMongoMapper::toDomain);
     }
 
     @Override
     public Optional<Course> findByName(String name) {
-        return Optional.empty();
+        return courseMongoRepository.findByName(name)
+                .map(courseMongoMapper::toDomain);
     }
 
     @Override

--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/out/persistence/mongo/repository/CourseMongoRepository.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/out/persistence/mongo/repository/CourseMongoRepository.java
@@ -6,8 +6,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.Optional;
+
 public interface CourseMongoRepository extends MongoRepository<CourseDocument, Long> {
     Page<CourseDocument> findByInstructorIdsContains(Long instructorId, Pageable pageable);
     Page<CourseDocument> findByStatus(CourseStatus status, Pageable pageable);
     Page<CourseDocument> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    Optional<CourseDocument> findByCode(String code);
+    Optional<CourseDocument> findByName(String name);
 }


### PR DESCRIPTION
## Summary
- Implement update, delete and find methods in JPA and Mongo persistence adapters
- Add repository support for lookup by code and name

## Testing
- `mvn -q -pl msvc-courses -am test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b24bbad89c83299fdc0484c3f0dbc3