### PR TITLE
Handle missing course in RetrieveCourseUseCaseImpl

### DIFF
--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/RetrieveCourseUseCaseImpl.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/application/usecase/RetrieveCourseUseCaseImpl.java
@@ -16,22 +16,28 @@ public class RetrieveCourseUseCaseImpl implements IRetrieveCourseUseCase {
 
     @Override
     public Optional<Course> getCourseById(Long idCourse) throws CourseNotFoundException {
-        Course course = courseRepositoryPort.findById(idCourse)
-                .orElseThrow(CourseNotFoundException::new);
-        return Optional.of(course);
+        Optional<Course> course = courseRepositoryPort.findById(idCourse);
+        if (course.isEmpty()) {
+            throw new CourseNotFoundException();
+        }
+        return course;
     }
 
     @Override
     public Optional<Course> getCourseByCode(String codeCourse) throws CourseNotFoundException {
-        Course course = courseRepositoryPort.findByCode(codeCourse)
-                .orElseThrow(CourseNotFoundException::new);
-        return Optional.of(course);
+        Optional<Course> course = courseRepositoryPort.findByCode(codeCourse);
+        if (course.isEmpty()) {
+            throw new CourseNotFoundException();
+        }
+        return course;
     }
 
     @Override
     public Optional<Course> getCourseByName(String nameCourse) throws CourseNotFoundException {
-        Course course = courseRepositoryPort.findByName(nameCourse)
-                .orElseThrow(CourseNotFoundException::new);
-        return Optional.of(course);
+        Optional<Course> course = courseRepositoryPort.findByName(nameCourse);
+        if (course.isEmpty()) {
+            throw new CourseNotFoundException();
+        }
+        return course;
     }
 }


### PR DESCRIPTION
## Summary
- Validate findBy results when retrieving courses
- Throw CourseNotFoundException if no course found

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b24cd5d6cc8329a3ed8f6c46d95a5a