### PR TITLE
feat: expand course controller endpoints

### DIFF
--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/in/web/dto/CourseRequestDTO.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/in/web/dto/CourseRequestDTO.java
@@ -1,0 +1,10 @@
+package com.borcla.springcloud.msvc.infrastructure.adapters.in.web.dto;
+
+import java.time.LocalDate;
+
+public record CourseRequestDTO(
+        String courseName,
+        String description,
+        LocalDate endDate
+) {
+}


### PR DESCRIPTION
## Summary
- add CRUD and extra actions to CourseController
- map domain Course to request and response DTOs

## Testing
- `mvn -q -pl msvc-courses test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b24d747e10832985794f96dc7789a0