### PR TITLE
Add global exception handler for course not found

### DIFF
--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/in/web/controller/GlobalExceptionHandler.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/in/web/controller/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.borcla.springcloud.msvc.infrastructure.adapters.in.web.controller;
+
+import com.borcla.springcloud.msvc.application.exception.CourseNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(CourseNotFoundException.class)
+    public ResponseEntity<Void> handleCourseNotFoundException(CourseNotFoundException ex) {
+        log.error("Course not found", ex);
+        return ResponseEntity.notFound().build();
+    }
+}


### PR DESCRIPTION
## Summary
- add a `@ControllerAdvice`-based global exception handler to translate `CourseNotFoundException` into `404` responses

## Testing
- `mvn -q -pl msvc-courses test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d083aa7083299ec15168eb5bf28e