### PR TITLE
Ensure Course mapper handles required fields

### DIFF
--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/out/persistence/jpa/mapper/ICourseJpaMapper.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/out/persistence/jpa/mapper/ICourseJpaMapper.java
@@ -4,10 +4,33 @@ import com.borcla.springcloud.msvc.domain.model.Course;
 import com.borcla.springcloud.msvc.infrastructure.adapters.out.persistence.jpa.entity.CourseEntity;
 import org.mapstruct.Mapper;
 
-import java.util.Optional;
-
 @Mapper(componentModel = "spring")
 public interface ICourseJpaMapper {
     CourseEntity toEntity(Course course);
-    Course toDomain(CourseEntity courseEntity);
+    default Course toDomain(CourseEntity courseEntity) {
+        if (courseEntity == null) {
+            return null;
+        }
+        Course course = new Course(
+                courseEntity.getName(),
+                courseEntity.getDescription(),
+                courseEntity.getEndDate()
+        );
+        course.setId(courseEntity.getId());
+        course.setCode(courseEntity.getCode());
+        course.setStatus(courseEntity.getStatus());
+        course.setModality(courseEntity.getModality());
+        course.setLevel(courseEntity.getLevel());
+        course.setLanguage(courseEntity.getLanguage());
+        course.setCapacity(courseEntity.getCapacity());
+        course.setEnrolledCount(courseEntity.getEnrolledCount());
+        course.setStartDate(courseEntity.getStartDate());
+        course.setPrice(courseEntity.getPrice());
+        course.setCurrency(courseEntity.getCurrency());
+        course.setInstructorIds(courseEntity.getInstructorIds());
+        course.setTags(courseEntity.getTags());
+        course.setCreatedAt(courseEntity.getCreatedAt());
+        course.setUpdatedAt(courseEntity.getUpdatedAt());
+        return course;
+    }
 }

--- a/msvc-courses/src/test/java/com/borcla/springcloud/msvc/infrastructure/adapters/out/persistence/jpa/CourseJpaPersistenceAdapterTest.java
+++ b/msvc-courses/src/test/java/com/borcla/springcloud/msvc/infrastructure/adapters/out/persistence/jpa/CourseJpaPersistenceAdapterTest.java
@@ -1,0 +1,44 @@
+package com.borcla.springcloud.msvc.infrastructure.adapters.out.persistence.jpa;
+
+import com.borcla.springcloud.msvc.domain.model.Course;
+import com.borcla.springcloud.msvc.infrastructure.adapters.out.persistence.jpa.entity.CourseEntity;
+import com.borcla.springcloud.msvc.infrastructure.adapters.out.persistence.jpa.mapper.ICourseJpaMapper;
+import com.borcla.springcloud.msvc.infrastructure.adapters.out.persistence.jpa.repository.JpaCourseRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+public class CourseJpaPersistenceAdapterTest {
+
+    @Test
+    void findByIdReturnsCourseWithMandatoryFields() {
+        JpaCourseRepository repo = Mockito.mock(JpaCourseRepository.class);
+        ICourseJpaMapper mapper = new ICourseJpaMapper() {
+            @Override
+            public CourseEntity toEntity(Course course) {
+                return null;
+            }
+        };
+        CourseEntity entity = new CourseEntity();
+        entity.setId(1L);
+        entity.setName("Test");
+        entity.setDescription("Desc");
+        entity.setEndDate(LocalDate.now());
+
+        when(repo.findById(1L)).thenReturn(Optional.of(entity));
+
+        CourseJpaPersistenceAdapter adapter = new CourseJpaPersistenceAdapter(mapper, repo);
+        Optional<Course> result = adapter.findById(1L);
+
+        assertTrue(result.isPresent());
+        Course course = result.get();
+        assertNotNull(course.getName());
+        assertNotNull(course.getDescription());
+        assertNotNull(course.getEndDate());
+    }
+}


### PR DESCRIPTION
## Summary
- Provide manual `toDomain` implementation in `ICourseJpaMapper` to map all course fields and avoid null values
- Add unit test verifying `findById` returns a course with mandatory fields populated

## Testing
- `mvn -q -pl msvc-courses -am test` *(fails: Non-resolvable parent POM for com.borcla.springcloud.msvc:borcla-academy:1.0-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d098a97883299c4c1762ab98dbaa