### PR TITLE
Handle missing courses with Optional in course API

### DIFF
--- a/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/in/web/controller/CourseController.java
+++ b/msvc-courses/src/main/java/com/borcla/springcloud/msvc/infrastructure/adapters/in/web/controller/CourseController.java
@@ -1,5 +1,6 @@
 package com.borcla.springcloud.msvc.infrastructure.adapters.in.web.controller;
 
+import com.borcla.springcloud.msvc.application.exception.CourseNotFoundException;
 import com.borcla.springcloud.msvc.application.services.CourseService;
 import com.borcla.springcloud.msvc.domain.model.Course;
 import com.borcla.springcloud.msvc.infrastructure.adapters.in.web.dto.request.CreateCourseRequest;
@@ -7,14 +8,20 @@ import com.borcla.springcloud.msvc.infrastructure.adapters.in.web.dto.request.Up
 import com.borcla.springcloud.msvc.infrastructure.adapters.in.web.dto.response.CourseCreatedResponse;
 import com.borcla.springcloud.msvc.infrastructure.adapters.in.web.dto.response.CourseSummaryResponse;
 import com.borcla.springcloud.msvc.infrastructure.adapters.in.web.mapper.ICourseWebMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Optional;
+
 @RestController
 @RequestMapping("/api/v1/courses")
 public class CourseController {
+
+    private static final Logger log = LoggerFactory.getLogger(CourseController.class);
 
     private final CourseService courseService;
     private final ICourseWebMapper courseWebMapper;
@@ -26,7 +33,19 @@ public class CourseController {
 
     @GetMapping("/{id}")
     public ResponseEntity<CourseSummaryResponse> findCourseById(@PathVariable Long id){
-        return ResponseEntity.ok(courseWebMapper.toSummaryDto(courseService.getCourseById(id)));
+        log.info("Retrieving course with id {}", id);
+
+        Course course = null;
+        try {
+            course = courseService.getCourseById(id);
+        } catch (CourseNotFoundException e) {
+            log.warn("Course with id {} not found", id);
+        }
+
+        return ResponseEntity.of(
+                Optional.ofNullable(course)
+                        .map(courseWebMapper::toSummaryDto)
+        );
     }
 
     @GetMapping


### PR DESCRIPTION
## Summary
- Wrap `findCourseById` in `CourseController` with `ResponseEntity.of` to return 404 when a course is missing
- Add logging for requested course ids and missing courses

## Testing
- `mvn -q -pl msvc-courses test` *(fails: Non-resolvable parent POM: network is unreachable)*
- `mvn -q -pl msvc-courses -Dspring.profiles.active=test spring-boot:run` *(fails: Non-resolvable parent POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d09e42a08329a7a6bdaa9fd02504